### PR TITLE
Update update-rp-filter.sh

### DIFF
--- a/rp_filter_settings/update-rp-filter.sh
+++ b/rp_filter_settings/update-rp-filter.sh
@@ -15,7 +15,7 @@ if [[ x"$NODE" == x ]]; then
   exit 1
 fi
 
-kubectl $CONTEXT --v=4 run netshoot-hostmount-$(uuidgen) --overrides='{
+kubectl $CONTEXT --v=4 run netshoot-hostmount-$(uuidgen | tr "[:upper:]" "[:lower:]") --overrides='{
 	"spec": {
 		"hostNetwork": true,
 		"nodeName": "'$NODE'",


### PR DESCRIPTION
"uuidgen" generates uppercase values which is a violation. Example: The Pod "netshoot-hostmount-D2E714B0-2285-45C5-B1D7-881F12783C8F" is invalid: metadata.name: Invalid value: "netshoot-hostmount-D2E714B0-2285-45C5-B1D7-881F12783C8F": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')